### PR TITLE
Explicit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "dfa-lib",
+  "version": "0.0.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dfa-lib",
+      "version": "0.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "cfgrammar-tool": "^1.0.0"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/cfgrammar-tool": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cfgrammar-tool/-/cfgrammar-tool-1.0.0.tgz",
+      "integrity": "sha512-ILAskaNpILXdncBuxGCaHQVgdCQaX4yBivmfIhpHl+n696PWIteNBiXETNjcdMMNe/jx/TDYvx6zthxUma18ng=="
+    }
+  },
+  "dependencies": {
+    "cfgrammar-tool": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cfgrammar-tool/-/cfgrammar-tool-1.0.0.tgz",
+      "integrity": "sha512-ILAskaNpILXdncBuxGCaHQVgdCQaX4yBivmfIhpHl+n696PWIteNBiXETNjcdMMNe/jx/TDYvx6zthxUma18ng=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "version": "0.0.3",
   "description": "Library for creation and manipulation of finite automata",
   "author": "bakkot",
-  "homepage": "https://github.com/shapesecurity/shift-parser-js",
+  "homepage": "https://github.com/bakkot/dfa-lib",
   "repository": {
     "type": "git",
     "url": "https://github.com/bakkot/dfa-lib.git"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "cfgrammar-tool": "^1.0.0"
+  },
   "directories": {},
   "main": "index.js",
-  "homepage": "https://github.com/bakkot/dfa-lib",
   "keywords": [
     "automata",
     "dfa",

--- a/regex.js
+++ b/regex.js
@@ -4,6 +4,7 @@ var NFA = lib.NFA;
 
 var astPrinter = gtool.printers.astPrinter;
 var parser = gtool.parser;
+var { Grammar, Rule, NT, T } = gtool.types;
 
 var rules = [
   Rule('U', [NT('C'), T('|'), NT('U')]), // union


### PR DESCRIPTION
Make dependency on cfgrammar-tool explicit, and import the T, NT, Grammar, Rule symbols explicitly.